### PR TITLE
[RFR] Fix the better grid with a non standard size

### DIFF
--- a/src/renderer/renderer.py
+++ b/src/renderer/renderer.py
@@ -32,7 +32,7 @@ def build_line(start_symb, stop_symb, sep_symb, line):
 def show_grid(grid):
     size = len(grid)
 
-    tile_line = np.full(size, '─' * size).tolist()
+    tile_line = np.full(size, '─' * 4).tolist()
 
     horizontal_line = build_line('├', '┤', '┼', tile_line)
     first_horizontal_line = build_line('┌', '┐', '┬', tile_line)

--- a/src/renderer/test_renderer.py
+++ b/src/renderer/test_renderer.py
@@ -58,6 +58,23 @@ class GameTest(TestCase):
         ]
         self.assertEqual(show_grid(grid), grid_rendered)
 
+    def test_show_grid_should_render_grid_with_custom_size(self):
+        grid_rendered = """
+┌────┬────┬────┐
+│  1 │  2 │  3 │
+├────┼────┼────┤
+│  4 │  5 │  6 │
+├────┼────┼────┤
+│  7 │  8 │    │
+└────┴────┴────┘
+"""  # noqa
+        grid = [
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 0]
+        ]
+        self.assertEqual(show_grid(grid), grid_rendered)
+
     def test_show_moves_should_render_possible_moves_msg(self):
         msg = 'You are allowed to move (12, 15)'
         self.assertEqual(show_moves([12, 15]), msg)


### PR DESCRIPTION
The better grid is broken when the user type a non standard width like 3. The tile size should not depend on the grid size.